### PR TITLE
New validatesSecureCertificate property to disable SLL validation (android only)

### DIFF
--- a/android/android/manifest
+++ b/android/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.2.1
+version: 3.2.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: av.imageview

--- a/android/android/src/av/imageview/ImageViewProxy.java
+++ b/android/android/src/av/imageview/ImageViewProxy.java
@@ -27,7 +27,7 @@ import android.os.Message;
 
 @Kroll.proxy(creatableInModule=ImageViewModule.class, propertyAccessors = {
 	"defaultImage", "brokenLinkImage", "image", "contentMode",  "enableMemoryCache",
-	"loadingIndicator", "enableMemoryCache", "rounded", "requestHeader", "handleCookies"
+	"loadingIndicator", "enableMemoryCache", "rounded", "requestHeader", "handleCookies", "validatesSecureCertificate"
 })
 public class ImageViewProxy extends TiViewProxy
 {
@@ -219,14 +219,14 @@ public class ImageViewProxy extends TiViewProxy
 	public String getLoadingIndicatorColor() {
 	    return getView().getLoadingIndicatorColor();
 	}
-	
+
 	@Kroll.setProperty
 	@Kroll.method
 	public void setLoadingIndicatorColor(String color) {
 		getView().setLoadingIndicatorColor(color);
 	}
 
-	
+
 	@Kroll.getProperty
 	@Kroll.method
 	public Boolean getMemoryCacheEnabled() {
@@ -265,5 +265,17 @@ public class ImageViewProxy extends TiViewProxy
 	@Kroll.method
 	public void setHandleCookies(Boolean handleCookies) {
 		getView().setHandleCookies(handleCookies);
+	}
+
+	@Kroll.getProperty
+	@Kroll.method
+	public Boolean getValidatesSecureCertificate() {
+		return getView().getValidatesSecureCertificate();
+	}
+
+	@Kroll.setProperty
+	@Kroll.method
+	public void setValidatesSecureCertificate(Boolean validatesSecureCertificate) {
+		getView().setValidatesSecureCertificate(validatesSecureCertificate);
 	}
 }


### PR DESCRIPTION
In some cases I need to disable SSL validation. With this new property (validatesSecureCertificate) we can disable.

Version change is not necessary. I just made it to identify the build.