### PR TITLE
FIX (iOS): requestHeaders parity with android

### DIFF
--- a/ios/Classes/AvImageviewImageView.h
+++ b/ios/Classes/AvImageviewImageView.h
@@ -27,7 +27,7 @@
   NSString *placeholderImagePath;
   NSString *brokenLinkImagePath;
 
-  NSDictionary *requestHeader;
+  NSDictionary *requestHeaders;
   id imageObject;
   BOOL configurationComplete;
 
@@ -45,7 +45,7 @@
 - (void)setLoadingIndicatorColor_:(id)args;
 - (void)setContentMode_:(id)args;
 - (void)setClipsToBounds_:(id)clips;
-- (void)setRequestHeader_:(id)args;
+- (void)setRequestHeaders_:(id)args;
 - (void)setTimeout_:(id)args;
 
 @end

--- a/ios/Classes/AvImageviewImageView.m
+++ b/ios/Classes/AvImageviewImageView.m
@@ -55,7 +55,7 @@
   [self setLoadingIndicator_:[self.proxy valueForKey:@"loadingIndicator"]];
   [self setLoadingIndicatorColor_:[self.proxy valueForKey:@"loadingIndicatorColor"]];
   [self setContentMode_:[self.proxy valueForKey:@"contentMode"]];
-  [self setRequestHeader_:[self.proxy valueForKey:@"requestHeader"]];
+  [self setRequestHeaders_:[self.proxy valueForKey:@"requestHeaders"]];
   [self setHandleCookies_:[self.proxy valueForKey:@"handleCookies"]];
 }
 
@@ -145,9 +145,9 @@
       [[SDWebImageDownloader sharedDownloader] setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 
       //Extending HTTP header with custom values
-      if (requestHeader != nil)
-        for (id key in requestHeader)
-          [[SDWebImageDownloader sharedDownloader] setValue:[requestHeader valueForKey:key] forHTTPHeaderField:key];
+      if (requestHeaders != nil)
+        for (id key in requestHeaders)
+          [[SDWebImageDownloader sharedDownloader] setValue:[requestHeaders valueForKey:key] forHTTPHeaderField:key];
 
       [imageView sd_setImageWithURL:imageUrl
                    placeholderImage:placeholderImage
@@ -318,8 +318,8 @@
   loadingIndicatorColor = [TiUtils colorValue:value];
 }
 
-- (void)setRequestHeader_:(id)args {
-  requestHeader = args;
+- (void)setRequestHeaders_:(id)args {
+  requestHeaders = args;
 }
 
 - (void)setHandleCookies_:(id)args {


### PR DESCRIPTION
With the latest module rewrite for android, parity was lost with requestHeader parameter. In my opinion it has more sense to have it in plural rather than in singular as it was before. 