### PR TITLE
fix(android): remove redundant activity reference that caused memory leak

### DIFF
--- a/android/src/av/imageview/ImageViewProxy.java
+++ b/android/src/av/imageview/ImageViewProxy.java
@@ -20,13 +20,10 @@ public class ImageViewProxy extends TiViewProxy  {
 
     private static final int MSG_FIRST_ID = TiViewProxy.MSG_LAST_ID + 1;
 
-    private Activity activity;
-
 	@Override
 	public TiUIView createView(Activity activity) {
-	    this.activity = activity;
 
-		TiUIView view = new AvImageView(this.activity, this);
+		TiUIView view = new AvImageView(activity, this);
 
 		view.getLayoutParams().autoFillsHeight = false;
 		view.getLayoutParams().autoFillsWidth = false;


### PR DESCRIPTION
- Remove unnecessary retained reference to view creation `activity`