### PR TITLE
fix(android): fix proxy check

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.2
+version: 5.0.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: av.imageview

--- a/android/src/av/imageview/utils/RequestListener.java
+++ b/android/src/av/imageview/utils/RequestListener.java
@@ -32,6 +32,8 @@ public class RequestListener implements com.bumptech.glide.request.RequestListen
 
     @Override
     public boolean onLoadFailed(@Nullable GlideException e, Object model, Target target, boolean isFirstResource) {
+        if (this.proxy == null) { return false; }
+        
         KrollDict currentProperties = this.proxy.get().getProperties();
 
         if (this.proxy.get().hasListeners(ImageViewConstants.EVENT_IMAGE_LOAD_ERROR)) {

--- a/android/src/av/imageview/utils/RequestListener.java
+++ b/android/src/av/imageview/utils/RequestListener.java
@@ -59,6 +59,8 @@ public class RequestListener implements com.bumptech.glide.request.RequestListen
 
     @Override
     public boolean onResourceReady(Object resource, Object model, Target target, DataSource dataSource, boolean isFirstResource) {
+        if (this.proxy == null || this.proxy.get() == null) { return false; }
+
         KrollDict currentProperties = this.proxy.get().getProperties();
 
         if (this.proxy.get().hasListeners(ImageViewConstants.EVENT_IMAGE_LOADED)) {

--- a/android/src/av/imageview/utils/RequestListener.java
+++ b/android/src/av/imageview/utils/RequestListener.java
@@ -32,7 +32,7 @@ public class RequestListener implements com.bumptech.glide.request.RequestListen
 
     @Override
     public boolean onLoadFailed(@Nullable GlideException e, Object model, Target target, boolean isFirstResource) {
-        if (this.proxy == null) { return false; }
+        if (this.proxy == null || this.proxy.get() == null) { return false; }
         
         KrollDict currentProperties = this.proxy.get().getProperties();
 


### PR DESCRIPTION
Fixes a `NullPointerException` in the `RequestListener.java`. Stack trace:

```
java.lang.NullPointerException: 
  at av.imageview.utils.RequestListener.onLoadFailed (RequestListener.java:35)
  at com.bumptech.glide.request.SingleRequest.onLoadFailed (SingleRequest.java:675)
  at com.bumptech.glide.request.SingleRequest.begin (SingleRequest.java:225)
  at com.bumptech.glide.manager.RequestTracker.resumeRequests (RequestTracker.java:115)
  at com.bumptech.glide.RequestManager.resumeRequests (RequestManager.java:327)
  at com.bumptech.glide.RequestManager.onStart (RequestManager.java:352)
  at com.bumptech.glide.manager.ActivityFragmentLifecycle.onStart (ActivityFragmentLifecycle.java:51)
  at com.bumptech.glide.manager.RequestManagerFragment.onStart (RequestManagerFragment.java:198)
  at android.app.Fragment.performStart (Fragment.java:2581)
  at android.app.FragmentManagerImpl.moveToState (FragmentManager.java:1344)
  at android.app.FragmentManagerImpl.moveFragmentToExpectedState (FragmentManager.java:1586)
  at android.app.FragmentManagerImpl.moveToState (FragmentManager.java:1658)
  at android.app.FragmentManagerImpl.dispatchMoveToState (FragmentManager.java:3068)
  at android.app.FragmentManagerImpl.dispatchStart (FragmentManager.java:3025)
  at android.app.FragmentController.dispatchStart (FragmentController.java:195)
  at android.app.Activity.performStart (Activity.java:8116)
  at android.app.ActivityThread.handleStartActivity (ActivityThread.java:3919)
  at android.app.servertransaction.TransactionExecutor.performLifecycleSequence (TransactionExecutor.java:235)
  at android.app.servertransaction.TransactionExecutor.cycleToPath (TransactionExecutor.java:215)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:187)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:105)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2473)
  at android.os.Handler.dispatchMessage (Handler.java:110)
  at android.os.Looper.loop (Looper.java:219)
  at android.app.ActivityThread.main (ActivityThread.java:8347)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:513)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1055)
```