### PR TITLE
fix(android): use application context

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.2
+version: 5.0.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: av.imageview

--- a/android/src/av/imageview/AvImageView.java
+++ b/android/src/av/imageview/AvImageView.java
@@ -1,6 +1,7 @@
 package av.imageview;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.ImageView;
@@ -14,7 +15,6 @@ import com.bumptech.glide.signature.ObjectKey;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
-import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
@@ -168,15 +168,20 @@ public class AvImageView extends TiUIView {
             signature = currentProperties.getString("signature");
         }
 
-        // Creating request builder
-        RequestBuilder builder = ImageViewHelper.prepareGlideClientFor(TiApplication.getInstance(), url);
-        builder = builder.listener(new RequestListener(proxy, this.progressBar));
-        builder = builder.apply(options);
-        builder = builder.load(url);
-        if (signature != null && !signature.equals("")) {
-            builder.signature(new ObjectKey(signature));
+        // Creating request builder. The activity may be null, e.g. when switching from light- to dark
+        // mode, which is fine because the image can remain as-is
+        Activity activity = proxy.getActivity();
+
+        if (activity != null) {
+            RequestBuilder builder = ImageViewHelper.prepareGlideClientFor(activity, url);
+            builder = builder.listener(new RequestListener(proxy, this.progressBar));
+            builder = builder.apply(options);
+            builder = builder.load(url);
+            if (signature != null && !signature.equals("")) {
+                builder.signature(new ObjectKey(signature));
+            }
+            builder.into(this.imageView);
         }
-        builder.into(this.imageView);
     }
 
     public void setImageAsLocalUri(String filename) {
@@ -193,13 +198,19 @@ public class AvImageView extends TiUIView {
             options = options.circleCrop();
         }
 
-        // Creating request builder
-        RequestBuilder<Drawable> builder = Glide.with(TiApplication.getInstance()).asDrawable();
-        builder = builder.listener(new RequestListener(proxy, this.progressBar));
-        builder = builder.apply(options);
-        builder = builder.load(imageDrawable);
 
-        builder.into(this.imageView);
+        // Creating request builder. The activity may be null, e.g. when switching from light- to dark
+        // mode, which is fine because the image can remain as-is
+        Activity activity = proxy.getActivity();
+
+        if (activity != null) {
+            RequestBuilder<Drawable> builder = Glide.with(activity).asDrawable();
+            builder = builder.listener(new RequestListener(proxy, this.progressBar));
+            builder = builder.apply(options);
+            builder = builder.load(imageDrawable);
+
+            builder.into(this.imageView);
+        }
     }
 
     public void setImageAsBlob(TiBlob blob) {

--- a/android/src/av/imageview/AvImageView.java
+++ b/android/src/av/imageview/AvImageView.java
@@ -14,6 +14,7 @@ import com.bumptech.glide.signature.ObjectKey;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
@@ -168,7 +169,7 @@ public class AvImageView extends TiUIView {
         }
 
         // Creating request builder
-        RequestBuilder builder = ImageViewHelper.prepareGlideClientFor(proxy.getActivity(), url);
+        RequestBuilder builder = ImageViewHelper.prepareGlideClientFor(TiApplication.getInstance(), url);
         builder = builder.listener(new RequestListener(proxy, this.progressBar));
         builder = builder.apply(options);
         builder = builder.load(url);
@@ -193,7 +194,7 @@ public class AvImageView extends TiUIView {
         }
 
         // Creating request builder
-        RequestBuilder<Drawable> builder = Glide.with(proxy.getActivity()).asDrawable();
+        RequestBuilder<Drawable> builder = Glide.with(TiApplication.getInstance()).asDrawable();
         builder = builder.listener(new RequestListener(proxy, this.progressBar));
         builder = builder.apply(options);
         builder = builder.load(imageDrawable);


### PR DESCRIPTION
There is a possible crash when loading images in a very early stage of the application lifetime:
```
[ERROR] TiExceptionHandler: (main) [17,95396] /alloy/controllers/settings/index.js:367
[ERROR] TiExceptionHandler: Error: You cannot start a load for a destroyed activity
[ERROR] TiExceptionHandler:     at Window.onFocus (/alloy/controllers/my-controller/index.js:100:20)
[ERROR] TiExceptionHandler:     at Window.value (ti:/kroll.js:1604:27)
[ERROR] TiExceptionHandler:     at Window.value (ti:/kroll.js:1656:25)
[ERROR] TiExceptionHandler:
[ERROR] TiExceptionHandler:     com.bumptech.glide.manager.RequestManagerRetriever.assertNotDestroyed(RequestManagerRetriever.java:317)
[ERROR] TiExceptionHandler:     com.bumptech.glide.manager.RequestManagerRetriever.get(RequestManagerRetriever.java:128)
[ERROR] TiExceptionHandler:     com.bumptech.glide.manager.RequestManagerRetriever.get(RequestManagerRetriever.java:108)
[ERROR] TiExceptionHandler:     com.bumptech.glide.Glide.with(Glide.java:776)
[ERROR] TiExceptionHandler:     av.imageview.ImageViewHelper.prepareGlideClientFor(ImageViewHelper.java:53)
[ERROR] TiExceptionHandler:     av.imageview.AvImageView.setImageAsURL(AvImageView.java:171)
[ERROR] TiExceptionHandler:     av.imageview.AvImageView.processProperty(AvImageView.java:116)
[ERROR] TiExceptionHandler:     av.imageview.AvImageView.propertyChanged(AvImageView.java:79)
[ERROR] TiExceptionHandler:     org.appcelerator.kroll.KrollProxy.firePropertyChanged(KrollProxy.java:992)
[ERROR] TiExceptionHandler:     org.appcelerator.kroll.KrollProxy.onPropertyChanged(KrollProxy.java:1087)
[ERROR] V8Exception: Exception occurred at /alloy/controllers/settings/index.js:367: Uncaught Error: You cannot start a load for a destroyed activity
```