### PR TITLE
android: local gif files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
-	implementation 'com.github.bumptech.glide:glide:4.13.2'
-	annotationProcessor 'com.github.bumptech.glide:compiler:4.13.2'
+	implementation 'com.github.bumptech.glide:glide:4.14.2'
+	annotationProcessor 'com.github.bumptech.glide:compiler:4.14.2'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.4
+version: 5.0.5
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: av.imageview

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.5
+version: 6.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: av.imageview
@@ -15,4 +15,4 @@ name: av.imageview
 moduleid: av.imageview
 guid: ec658f35-69c8-45fa-8f7c-6354b4f761b4
 platform: android
-minsdk: 9.0.0
+minsdk: 12.7.0

--- a/android/src/av/imageview/AvImageView.java
+++ b/android/src/av/imageview/AvImageView.java
@@ -180,6 +180,9 @@ public class AvImageView extends TiUIView {
     }
 
     public void setImageAsLocalUri(String filename) {
+        if (proxy == null || proxy.getActivity() == null) {
+            return;
+        }
         Drawable imageDrawable = TiDrawableReference.fromUrl(proxy, filename).getDrawable();
         KrollDict currentProperties = proxy.getProperties();
         String mimeType = ImageViewHelper.getMimeTypeFor(filename);
@@ -198,10 +201,10 @@ public class AvImageView extends TiUIView {
         RequestBuilder builder;
         if (mimeType.equals("image/gif")) {
             // local gif file
-            builder = Glide.with(proxy.getActivity().getApplicationContext()).asGif();
+            builder = Glide.with(proxy.getActivity()).asGif();
             builder = builder.load(TiDrawableReference.fromUrl(proxy, filename).getUrl());
-        }  else {
-            builder = Glide.with(proxy.getActivity().getApplicationContext()).asDrawable();
+        } else {
+            builder = Glide.with(proxy.getActivity()).asDrawable();
             builder = builder.load(imageDrawable);
         }
         builder = builder.listener(new RequestListener(proxy, this.progressBar));

--- a/android/src/av/imageview/AvImageView.java
+++ b/android/src/av/imageview/AvImageView.java
@@ -14,6 +14,7 @@ import com.bumptech.glide.signature.ObjectKey;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
@@ -181,6 +182,7 @@ public class AvImageView extends TiUIView {
     public void setImageAsLocalUri(String filename) {
         Drawable imageDrawable = TiDrawableReference.fromUrl(proxy, filename).getDrawable();
         KrollDict currentProperties = proxy.getProperties();
+        String mimeType = ImageViewHelper.getMimeTypeFor(filename);
 
         RequestOptions options = new RequestOptions();
 
@@ -193,10 +195,17 @@ public class AvImageView extends TiUIView {
         }
 
         // Creating request builder
-        RequestBuilder<Drawable> builder = Glide.with(proxy.getActivity()).asDrawable();
+        RequestBuilder builder;
+        if (mimeType.equals("image/gif")) {
+            // local gif file
+            builder = Glide.with(TiApplication.getAppRootOrCurrentActivity().getApplicationContext()).asGif();
+            builder = builder.load(TiDrawableReference.fromUrl(proxy, filename).getUrl());
+        }  else {
+            builder = Glide.with(TiApplication.getAppRootOrCurrentActivity().getApplicationContext()).asDrawable();
+            builder = builder.load(imageDrawable);
+        }
         builder = builder.listener(new RequestListener(proxy, this.progressBar));
         builder = builder.apply(options);
-        builder = builder.load(imageDrawable);
 
         builder.into(this.imageView);
     }

--- a/android/src/av/imageview/AvImageView.java
+++ b/android/src/av/imageview/AvImageView.java
@@ -198,10 +198,10 @@ public class AvImageView extends TiUIView {
         RequestBuilder builder;
         if (mimeType.equals("image/gif")) {
             // local gif file
-            builder = Glide.with(TiApplication.getAppRootOrCurrentActivity().getApplicationContext()).asGif();
+            builder = Glide.with(proxy.getActivity().getApplicationContext()).asGif();
             builder = builder.load(TiDrawableReference.fromUrl(proxy, filename).getUrl());
         }  else {
-            builder = Glide.with(TiApplication.getAppRootOrCurrentActivity().getApplicationContext()).asDrawable();
+            builder = Glide.with(proxy.getActivity().getApplicationContext()).asDrawable();
             builder = builder.load(imageDrawable);
         }
         builder = builder.listener(new RequestListener(proxy, this.progressBar));

--- a/android/src/av/imageview/AvImageView.java
+++ b/android/src/av/imageview/AvImageView.java
@@ -199,7 +199,7 @@ public class AvImageView extends TiUIView {
 
         // Creating request builder
         RequestBuilder builder;
-        if ("image/gif".equals(mimeType)) {
+        if (mimeType != null && "image/gif".equals(mimeType)) {
             // local gif file
             builder = Glide.with(proxy.getActivity()).asGif();
             builder = builder.load(TiDrawableReference.fromUrl(proxy, filename).getUrl());

--- a/android/src/av/imageview/AvImageView.java
+++ b/android/src/av/imageview/AvImageView.java
@@ -199,7 +199,7 @@ public class AvImageView extends TiUIView {
 
         // Creating request builder
         RequestBuilder builder;
-        if (mimeType.equals("image/gif")) {
+        if ("image/gif".equals(mimeType)) {
             // local gif file
             builder = Glide.with(proxy.getActivity()).asGif();
             builder = builder.load(TiDrawableReference.fromUrl(proxy, filename).getUrl());


### PR DESCRIPTION
* small library bump
* add support for local GIF files

Test:
```js
var avImageView = require('av.imageview');
const win = Ti.UI.createWindow();
const img = avImageView.createImageView({
	top: 0,
	image: "https://blog.jitter.video/content/images/2021/12/Figma-animation-1.gif",
  height: 200
});
const img2 = avImageView.createImageView({
	bottom: 0,
  height: 200,
	image: "/images/demo.gif",
});
win.add(img);
win.add(img2);
win.open();
```

make sure to have a local file in that folder

[av.imageview-android-6.0.0.zip](https://github.com/user-attachments/files/24616813/av.imageview-android-6.0.0.zip)
